### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,4 +1,6 @@
 name: Python CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/DanielCreggOrganization/w10-lab-ai-cicd-tomaspettit2506/security/code-scanning/1](https://github.com/DanielCreggOrganization/w10-lab-ai-cicd-tomaspettit2506/security/code-scanning/1)

To fix this issue, we should add an explicit `permissions` block to the workflow or the job. For this workflow, since only local actions are performed (no repository writes, no GitHub API interactions requiring elevated permissions), the minimal correct configuration would be to set `contents: read`, which allows jobs to fetch and read repository contents but not to modify them. Since there is only one job and no other jobs are shown, it's simplest and clearest to set the `permissions` block at the workflow root level, immediately after the `name:` declaration. This ensures all jobs have the least privileges possible unless otherwise specified.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
